### PR TITLE
gather-class-name-change

### DIFF
--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -5,7 +5,7 @@ import stylesGather from './styles';
 
 Mapbox.setAccessToken('pk.eyJ1IjoicXFtZWxvIiwiYSI6ImNqbWlhOXh2eDAwMHMzcm1tNW1veDNmODYifQ.vOmFAXiikWFJKh3DpmsPDA');
 
-export default class App extends Component {
+export default class Gather extends Component {
   constructor(props) {
     super(props);
     this.props = props;


### PR DESCRIPTION
Gather.js
  - Renamed class name from 'App' to 'Gather'