### PR TITLE
bug-fix-upgrading-react-native-navigation

### DIFF
--- a/android/app/src/main/java/com/reciclando/MainApplication.java
+++ b/android/app/src/main/java/com/reciclando/MainApplication.java
@@ -70,7 +70,6 @@ public class MainApplication extends NavigationApplication {
         return mReactNativeHost;
     }
 
-    @Override
     public boolean clearHostOnActivityDestroy() {
         return false;
     }


### PR DESCRIPTION
There seemed to be a bug in the pr "header-style" related to the package.lock.json, that made the command `react-native run-android` crash on building. It should be working now.