### PR TITLE
modal-input-fix

### DIFF
--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -149,7 +149,7 @@ class Gather extends Component {
           >
             <Image source={icon} style={stylesGather.trashIcon} />
             <Mapbox.Callout title={strings.collectionPoint} />
-          
+
           </Mapbox.PointAnnotation>
           <Mapbox.PointAnnotation
             key="pointAnnotation2"

--- a/src/components/Gather/styles.js
+++ b/src/components/Gather/styles.js
@@ -17,7 +17,7 @@ const stylesGather = StyleSheet.create({
   },
   overlayDayText: {
     color: Colors.white,
-    fontSize: 25,
+    fontSize: 20,
   },
   button: {
     justifyContent: 'center',

--- a/src/components/common/CreateBaleModal.js
+++ b/src/components/common/CreateBaleModal.js
@@ -79,6 +79,7 @@ class CreateBaleModal extends Component {
             <TextField
               placeholder={strings.weighPlaceholderModal}
               keyboardType="numeric"
+              maxLength={8}
               onChangeText={value => this.setState({ newWeight: value })}
             />
             <Picker

--- a/src/components/common/CreatePocketModal.js
+++ b/src/components/common/CreatePocketModal.js
@@ -78,11 +78,13 @@ class CreatePocketModal extends Component {
             <TextField
               placeholder={strings.identifierPlaceholderModal}
               keyboardType="numeric"
+              maxLength={8}
               onChangeText={value =>
                 (this.setState({ identifier: value }))}
             />
             <TextField
               placeholder={strings.descriptionPlaceholderModal}
+              maxLength={23}
               onChangeText={value =>
                 (this.setState({ description: value }))}
             />

--- a/src/components/common/EditBaleModal.js
+++ b/src/components/common/EditBaleModal.js
@@ -84,6 +84,7 @@ class EditBaleModal extends Component {
             <TextField
               placeholder={strings.weighPlaceholderModal}
               keyboardType="numeric"
+              maxLength={8}
               onChangeText={value => this.setState({ newWeight: value })}
             />
             <Picker


### PR DESCRIPTION
Gather.js:
  - Removed unnecessary spaces.

Gather/styles.js:
  - Reduced date font. Bigger letters made it difficult to fit large week names such as Wednesday, causing graphical glitches.

CreateBaleModal.js, EditBaleModal.js, CreatePocketModal.js:
  - Added a cap for input fields. Large inputs caused the modals to behave unexpectedly.