### PR TITLE
confirm-exit-gather-trip-started

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3031,7 +3031,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",

--- a/src/__test__/__reducers__/Edit-bale-modal-reducer.test.js
+++ b/src/__test__/__reducers__/Edit-bale-modal-reducer.test.js
@@ -31,6 +31,8 @@ describe('edit bale modal reducer', () => {
       baleData: false,
       editBaleModalIsOpen: false,
       isLoading: false,
+      material: false,
+      weight: false,
     });
   });
 

--- a/src/actions/GatherActions.js
+++ b/src/actions/GatherActions.js
@@ -109,7 +109,6 @@ export const addPocketToCollection = (
     await GatherController.addPocketToCollection(token, routeId, collectionId, pocketsArray);
     dispatch(addPocketSuccess());
   } catch (error) {
-    console.log(error);
     dispatch(addPocketError(error.message));
   }
 };
@@ -120,7 +119,6 @@ export const endCollection = (token, routeId, routeLength, routeImage) => async 
     await GatherController.endCollection(token, routeId, routeLength, routeImage);
     dispatch(endCollectionSuccess());
   } catch (error) {
-    console.log('error en el end', error);
     dispatch(endCollectionError(error.message));
   }
 };

--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -109,24 +109,11 @@ class Gather extends Component {
     this.backHandler.remove();
   }
 
-  onNavigatorEvent(event) {
-    switch (event.id) {
-      case 'sideMenuIcon':
-        this.props.navigator.toggleDrawer({
-          side: 'right',
-          animated: true,
-          to: 'open',
-        });
-        break;
-      case 'logo':
-        this.toggleConfirmExitModal(() => {
-          this.changeRole();
-          this.finishTravel();
-        });
-        break;
-      default:
-        break;
-    }
+  onNavigatorEvent() {
+    this.toggleConfirmExitModal(() => {
+      this.changeRole();
+      this.finishTravel();
+    });
   }
 
   setButtonsTablet = (name) => {

--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -103,7 +103,7 @@ class Gather extends Component {
       error => this.setState({ error: error.message }),
       { timeout: 20000, distanceFilter: 1 },
     );
-    this.backHandler = BackHandler.addEventListener('hardwareBackPress', this.changeRoleOnBackPress);
+    this.backHandler = BackHandler.addEventListener('hardwareBackPress', this.backButtonPressOverride);
   }
 
   componentWillUnmount() {
@@ -174,7 +174,7 @@ class Gather extends Component {
     return 0;
   }
 
-  changeRoleOnBackPress = () => {
+  backButtonPressOverride = () => {
     this.toggleConfirmExitModal(() => {
       this.finishTravel();
       this.changeRole();

--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -78,8 +78,6 @@ class Gather extends Component {
     // requestLocationPermission();
     if (isTablet || this.state.landscape) {
       this.setButtonsTablet(this.props.user);
-    } else {
-      this.setButtonsPhone();
     }
 
     this.watchId = navigator.geolocation.watchPosition(
@@ -151,13 +149,6 @@ class Gather extends Component {
           },
         },
       ],
-      animated: false,
-    });
-  };
-
-  setButtonsPhone = () => {
-    this.props.navigator.setButtons({
-      rightButtons: [],
       animated: false,
     });
   };

--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -25,7 +25,6 @@ import user128 from '../../assets/ic_user/ic_user128.png';
 import strings from '../../localization';
 import { Screens } from '../Navigation';
 import CreatePocketModal from '../common/CreatePocketModal';
-// import requestLocationPermission from '../../helpers/Permissions';
 import CustomButton from '../common/CustomButton';
 import TickIcon from '../../assets/images/Tick.png';
 import {
@@ -75,7 +74,6 @@ class Gather extends Component {
   }
 
   componentDidMount() {
-    // requestLocationPermission();
     if (isTablet || this.state.landscape) {
       this.setButtonsTablet(this.props.user);
     }

--- a/src/components/Gather/Gather.js
+++ b/src/components/Gather/Gather.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
-import { View, Image, Text, Alert, TouchableOpacity, ActivityIndicator } from 'react-native';
-import Modal from 'react-native-modal';
+import { View, Image, TouchableOpacity, BackHandler } from 'react-native';
 import Mapbox from '@mapbox/react-native-mapbox-gl';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -15,7 +14,6 @@ import {
   setContainerId,
 } from '../../actions/GatherActions';
 import { openCreatePocketModal } from '../../actions/CreatePocketModalActions';
-import plusSign from '../../assets/ic_common/ic_add.png';
 import getUser from '../../selectors/UserSelector';
 import getRole from '../../selectors/RoleSelector';
 import getCollection from '../../selectors/RouteSelector';
@@ -24,11 +22,10 @@ import Colors from '../../helpers/Colors';
 import icon from '../../assets/images/MapPointIcon.png';
 import Logo01 from '../../assets/images/Logo01.png';
 import user128 from '../../assets/ic_user/ic_user128.png';
-import sideMenuIcon from '../../assets/ic_common/ic_hamburger.png';
 import strings from '../../localization';
 import { Screens } from '../Navigation';
 import CreatePocketModal from '../common/CreatePocketModal';
-import requestLocationPermission from '../../helpers/Permissions';
+// import requestLocationPermission from '../../helpers/Permissions';
 import CustomButton from '../common/CustomButton';
 import TickIcon from '../../assets/images/Tick.png';
 import {
@@ -39,39 +36,11 @@ import {
   selectPocketCounter,
 } from '../../selectors/GatherSelector';
 import GatherOverlay from './GatherOverlay';
+import GatherPointOptionModal from './GatherPointOptionModal';
+import GatherConfirmExitTripStartedModal from './GatherConfrimExitTripStartedModal';
 import stylesGather from './styles';
 
 Mapbox.setAccessToken('pk.eyJ1IjoicXFtZWxvIiwiYSI6ImNqbWlhOXh2eDAwMHMzcm1tNW1veDNmODYifQ.vOmFAXiikWFJKh3DpmsPDA');
-
-const GatherPointOptionModal = ({ isVisible, onPressActionFst, onPressActionSnd }) => (
-  <Modal
-    isVisible={isVisible}
-    onBackdropPress={onPressActionFst}
-    onBackButtonPress={onPressActionFst}
-    animationOut="slideOutLeft"
-  >
-    <View style={stylesGather.modalContainer}>
-      <View style={stylesGather.modalTitleContainer}>
-        <Text style={stylesGather.modalTitle}>{strings.optionsModalGather}</Text>
-      </View>
-      <View>
-        <CustomButton
-          style={stylesGather.buttonModal}
-          textStyle={stylesGather.textButton}
-          title={strings.newPocket}
-          onPress={onPressActionSnd}
-          icon={plusSign}
-        />
-      </View>
-    </View>
-  </Modal>
-);
-
-GatherPointOptionModal.propTypes = {
-  isVisible: PropTypes.bool.isRequired,
-  onPressActionFst: PropTypes.func.isRequired,
-  onPressActionSnd: PropTypes.func.isRequired,
-};
 
 class Gather extends Component {
   static navigatorStyle = {
@@ -98,7 +67,9 @@ class Gather extends Component {
       distanceTravelled: 0,
       prevLatLng: null,
       finish: false,
-      isModalVisible: false,
+      isOptionModalVisible: false,
+      isConfirmExitModalVisible: false,
+      confrimExitFunction: () => ({}),
     };
     this.props.navigator.setOnNavigatorEvent(this.onNavigatorEvent.bind(this));
   }
@@ -132,10 +103,12 @@ class Gather extends Component {
       error => this.setState({ error: error.message }),
       { timeout: 20000, distanceFilter: 1 },
     );
+    this.backHandler = BackHandler.addEventListener('hardwareBackPress', this.changeRoleOnBackPress);
   }
 
   componentWillUnmount() {
     navigator.geolocation.clearWatch(this.watchId);
+    this.backHandler.remove();
   }
 
   onNavigatorEvent(event) {
@@ -148,7 +121,10 @@ class Gather extends Component {
         });
         break;
       case 'logo':
-        this.changeRole();
+        this.toggleConfirmExitModal(() => {
+          this.changeRole();
+          this.finishTravel();
+        });
         break;
       default:
         break;
@@ -181,13 +157,7 @@ class Gather extends Component {
 
   setButtonsPhone = () => {
     this.props.navigator.setButtons({
-      rightButtons: [
-        {
-          icon: sideMenuIcon,
-          id: 'sideMenuIcon',
-          buttonColor: Colors.white,
-        },
-      ],
+      rightButtons: [],
       animated: false,
     });
   };
@@ -204,30 +174,45 @@ class Gather extends Component {
     return 0;
   }
 
-  toggleModal = (containerId) => {
-    if (!this.state.isModalVisible) {
+  changeRoleOnBackPress = () => {
+    this.toggleConfirmExitModal(() => {
+      this.finishTravel();
+      this.changeRole();
+    });
+    return true;
+  }
+
+  toggleOptionModal = (containerId) => {
+    if (!this.state.isOptionModalVisible) {
       this.props.setContainerId(containerId);
     }
-    this.setState({ isModalVisible: !this.state.isModalVisible });
+    this.setState({ isOptionModalVisible: !this.state.isOptionModalVisible });
   };
 
   toggleCreatePocketModal = () => {
-    this.toggleModal();
+    this.toggleOptionModal();
     this.props.openCreatePocketModal();
+  };
+
+  toggleConfirmExitModal = (navigationFunction) => {
+    this.setState({
+      isConfirmExitModalVisible: !this.state.isConfirmExitModalVisible,
+      confrimExitFunction: () => {
+        this.setState({ isConfirmExitModalVisible: !this.state.isConfirmExitModalVisible });
+        navigationFunction();
+      },
+    });
   };
 
   changeRole = () => {
     this.props.changeRole();
-    this.props.navigator.push({
-      screen: Screens.Roles,
-      animationType: 'fade',
-    });
+    this.props.navigator.pop();
   };
 
   finishTravel = () => {
     this.setState({ finish: true });
     if (this.state.distanceTravelled === 0) {
-      this.state.distanceTravelled = 0.01;
+      this.setState({ distanceTravelled: 0.01 });
     }
     this.props.endCollection(
       this.props.token,
@@ -240,12 +225,15 @@ class Gather extends Component {
       this.state.distanceTravelled,
       this.props.pocketCounter,
     );
+  };
 
+  completeTravel = () => {
+    this.finishTravel();
     this.props.navigator.push({
       screen: Screens.TravelFinished,
       animationType: 'fade',
     });
-  };
+  }
 
   renderContainers = containers =>
     containers.map(container => (
@@ -253,7 +241,7 @@ class Gather extends Component {
         id={container.id.toString()}
         coordinate={[Number(container.longitude), Number(container.latitude)]}
       >
-        <TouchableOpacity onPress={() => this.toggleModal(container.id)}>
+        <TouchableOpacity onPress={() => this.toggleOptionModal(container.id)}>
           <Image source={icon} style={stylesGather.trashIcon} />
         </TouchableOpacity>
       </Mapbox.PointAnnotation>
@@ -274,18 +262,22 @@ class Gather extends Component {
           textStyle={
             isTablet ? stylesGather.textButtonOverMapTablet : stylesGather.textButtonOverMapPhone
           }
-          onPress={this.finishTravel}
+          onPress={this.completeTravel}
         />
 
         <CreatePocketModal
           collectionId={this.props.collectionId}
           containerIdSelected={this.props.containerIdSelected}
         />
-
         <GatherPointOptionModal
-          isVisible={this.state.isModalVisible}
-          onPressActionFst={this.toggleModal}
+          isVisible={this.state.isOptionModalVisible}
+          onPressActionFst={this.toggleOptionModal}
           onPressActionSnd={this.toggleCreatePocketModal}
+        />
+        <GatherConfirmExitTripStartedModal
+          isVisible={this.state.isConfirmExitModalVisible}
+          onPressActionFst={() => { this.toggleConfirmExitModal(() => {}); }}
+          onPressActionSnd={this.state.confrimExitFunction}
         />
         <Mapbox.MapView
           styleURL={Mapbox.StyleURL.Street}

--- a/src/components/Gather/GatherConfrimExitTripStartedModal.js
+++ b/src/components/Gather/GatherConfrimExitTripStartedModal.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text } from 'react-native';
+import Modal from 'react-native-modal';
+import strings from '../../localization';
+import CustomButton from '../common/CustomButton';
+import stylesGather from './styles';
+
+const GatherConfirmExitTripStartedModal = ({ isVisible, onPressActionFst, onPressActionSnd }) => (
+  <Modal
+    isVisible={isVisible}
+    onBackdropPress={onPressActionFst}
+    onBackButtonPress={onPressActionFst}
+  >
+    <View style={stylesGather.modalContainer}>
+      <View style={stylesGather.modalTitleContainer}>
+        <Text style={stylesGather.modalTitle}>{strings.confirmExitTripStartedTitle}</Text>
+        <Text style={stylesGather.modalSubitle}>{strings.confirmExitTripStartedSubtitle}</Text>
+      </View>
+      <View style={stylesGather.modalButtonContainer}>
+        <View style={{ paddingRight: 10 }}>
+          <CustomButton
+            style={stylesGather.buttonModalConfirmExit}
+            textStyle={stylesGather.textButton}
+            title={strings.acceptModal}
+            onPress={onPressActionSnd}
+          />
+        </View>
+        <View style={{ paddingLeft: 10 }}>
+          <CustomButton
+            style={stylesGather.buttonModalConfirmExit}
+            textStyle={stylesGather.textButton}
+            title={strings.cancelModal}
+            onPress={onPressActionFst}
+          />
+        </View>
+      </View>
+    </View>
+  </Modal>
+);
+
+GatherConfirmExitTripStartedModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onPressActionFst: PropTypes.func.isRequired,
+  onPressActionSnd: PropTypes.func.isRequired,
+};
+
+export default GatherConfirmExitTripStartedModal;

--- a/src/components/Gather/GatherPointOptionModal.js
+++ b/src/components/Gather/GatherPointOptionModal.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { View, Text } from 'react-native';
+import Modal from 'react-native-modal';
+import strings from '../../localization';
+import CustomButton from '../common/CustomButton';
+import plusSign from '../../assets/ic_common/ic_add.png';
+import stylesGather from './styles';
+
+const GatherPointOptionModal = ({ isVisible, onPressActionFst, onPressActionSnd }) => (
+  <Modal
+    isVisible={isVisible}
+    onBackdropPress={onPressActionFst}
+    onBackButtonPress={onPressActionFst}
+    animationOut="slideOutLeft"
+  >
+    <View style={stylesGather.modalContainer}>
+      <View style={stylesGather.modalTitleContainer}>
+        <Text style={stylesGather.modalTitle}>{strings.optionsModalGather}</Text>
+      </View>
+      <View>
+        <CustomButton
+          style={stylesGather.buttonModal}
+          textStyle={stylesGather.textButton}
+          title={strings.newPocket}
+          onPress={onPressActionSnd}
+          icon={plusSign}
+        />
+      </View>
+    </View>
+  </Modal>
+);
+
+GatherPointOptionModal.propTypes = {
+  isVisible: PropTypes.bool.isRequired,
+  onPressActionFst: PropTypes.func.isRequired,
+  onPressActionSnd: PropTypes.func.isRequired,
+};
+
+export default GatherPointOptionModal;

--- a/src/components/Gather/styles.js
+++ b/src/components/Gather/styles.js
@@ -114,13 +114,35 @@ const stylesGather = StyleSheet.create({
     padding: 5,
     borderRadius: 5,
   },
+  buttonModalConfirmExit: {
+    width: 125,
+    backgroundColor: Colors.primary,
+    alignSelf: 'stretch',
+    borderColor: Colors.primary,
+    borderWidth: 1,
+    marginTop: 10,
+    padding: 10,
+    borderRadius: 5,
+  },
   modalTitleContainer: {
     paddingTop: 15,
     paddingBottom: 20,
+    paddingLeft: 75,
+    paddingRight: 75,
+  },
+  modalButtonContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
   },
   modalTitle: {
     fontSize: 30,
     color: Colors.primary,
+    textAlign: 'center',
+  },
+  modalSubitle: {
+    fontSize: 20,
+    color: Colors.black,
+    textAlign: 'center',
   },
   buttonText: {
     fontSize: 15,

--- a/src/components/TravelFinished/TravelFinished.js
+++ b/src/components/TravelFinished/TravelFinished.js
@@ -97,6 +97,10 @@ class TravelFinished extends Component {
     }, 1000);
   }
 
+  componentWillUnmount() {
+    this.backHandler.remove();
+  }
+
   onNavigatorEvent(event) {
     switch (event.id) {
       case 'logo':

--- a/src/localization/en.js
+++ b/src/localization/en.js
@@ -56,6 +56,7 @@ export default {
 
   // Common Modal
   acceptModal: 'Accept ',
+  cancelModal: 'Cancel ',
   weighPlaceholderModal: 'Weight (kg) ',
   selectMaterial: 'Select a new material ',
   invalidInputNumber: 'Please enter a valid number ',
@@ -97,10 +98,14 @@ export default {
   information: 'Information ',
   collectionPoint: 'Collection point ',
 
-  // Gather secondary modal
+  // Gather option modal
   changeStateIsle: 'Change state ',
   newPocket: 'New pocket ',
   optionsModalGather: 'Options ',
+
+  // Gather confirm exit modal
+  confirmExitTripStartedTitle: 'Are you sure you want to exit? ',
+  confirmExitTripStartedSubtitle: 'You\'ve started a trip, if you exit now all progress will be lost ',
 
   // Errors
   error: 'Error ',

--- a/src/localization/es.js
+++ b/src/localization/es.js
@@ -104,8 +104,8 @@ export default {
   optionsModalGather: 'Opciones ',
 
   // Gather confrim exit modal
-  confirmExitTripStartedTitle: 'Estas seguro de que quieres salir? ',
-  confirmExitTripStartedSubtitle: 'Tienes un viaje comenzado, si sales perderás todo el progreso realizado ',
+  confirmExitTripStartedTitle: '¿Está seguro de que quiere salir? ',
+  confirmExitTripStartedSubtitle: 'Tiene un viaje comenzado, si sale perderá todo el progreso realizado ',
 
   // Errors
   error: 'Error ',

--- a/src/localization/es.js
+++ b/src/localization/es.js
@@ -56,6 +56,7 @@ export default {
 
   // Common Modal
   acceptModal: 'Aceptar ',
+  cancelModal: 'Cancelar ',
   weighPlaceholderModal: 'Peso (kg) ',
   selectMaterial: 'Seleccione un nuevo material ',
   invalidInputNumber: 'Por favor ingrese un número válido ',
@@ -97,10 +98,14 @@ export default {
   information: 'Información ',
   collectionPoint: 'Punto de recolección ',
 
-  // Gather secondary modal
+  // Gather option modal
   changeStateIsle: 'Cambiar estado ',
   newPocket: 'Agregar bolsón ',
   optionsModalGather: 'Opciones ',
+
+  // Gather confrim exit modal
+  confirmExitTripStartedTitle: 'Estas seguro de que quieres salir? ',
+  confirmExitTripStartedSubtitle: 'Tienes un viaje comenzado, si sales perderás todo el progreso realizado ',
 
   // Errors
   error: 'Error ',


### PR DESCRIPTION
 New:
  - GatherPointOptionModal.js
  - GatherConfirmExitTripStartedModal.js please refer to its implementation details below since the way this modal is wired up at Gather.js is rather complex.

Modified:
Gather.js
  - Removed unnecessary imports
  - Commented out requestLocationPermission import to match its commented function call
  - Removed GatherPointOptionModal (now it has its own file)
  - Changed state variable from isModalVisible to isOptionModalVisible
  - Changed toggleModal function name to toggleOptionmodal
  - Added back button support for opening the modal and its assocaited function
  - Removed drawer button from the screen
  - Fixed change role function doing a push instead of a pop.
  - Fixed finishTravel wrongfully assigning values to state instead of using setState. 
  - Changed the finish travel function to be split into two halves, the first one finishes the travel logically and the second makes the transition to the finish travel window.

GatherActions.js
   - Removed console log

gather/styles.js
   - Added several new styles for the new modal

TravelFinished.js
   - Fixed bug that once this screen was visited, the back button would always do two pops.

localization/en.js and localization/es.js
   - Added several new strings for the new modal.

Implementation details:
GatherConfirmExitTripStartedModal: This is a modal that receives a function in its accept button. This function is modeled in the Gather.js file as the state variable `confrimExitFunction` which by default its an empty arrow function as seen on line 72. Since this function depends on which button calls the modal, the function `toggleConfirmExitModal` (line 197) receives as a parameter `navigationFunction` and sets it to said state. Since the function being passed is just navigation, the `confrimExitFunction` must also toggle the modal once its called, otherwise we would simply navigate through screens but the modal would never be turned off. If you have followed me so far you'll get why im doing what im doing on line 279. To explain it, lets consider the following possibilities:

 - `onPressActionFst={this.toggleConfirmExitModal}`: Wont work. If the modal is called the state value for `confrimExitFunction` will contain a `navigationFunction` that isn't empty, which is not what we want when we press the cancel option. We are passing the function, yes, but we're not giving any values for the parameter `navigationFunction`. 

 - `onPressActionFst={this.toggleConfirmExitModal(() => {}}`: Looks ok, but wont work either. This will execute the function and pass the result to the modal, which would result in closing the modal as soon as it opens.

Since we want to pass a function we must first create it.