### PR TITLE
Navigation fix

### DIFF
--- a/src/components/Bale/Bale.js
+++ b/src/components/Bale/Bale.js
@@ -117,10 +117,7 @@ class Bale extends Component {
 
   changeRole = () => {
     this.props.changeRole();
-    this.props.navigator.push({
-      screen: Screens.Roles,
-      animationType: 'fade',
-    });
+    this.props.navigator.pop();
   };
 
   render() {

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -12,6 +12,7 @@ import strings from '../../localization';
 import { login, actionTypes } from '../../actions/LoginActions';
 import { errorsSelector } from '../../selectors/ErrorSelector';
 import { Screens } from '../Navigation';
+import Application from '../../Application';
 import styles from './styles';
 
 class Login extends Component {
@@ -29,10 +30,7 @@ class Login extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.isLoading && nextProps.organization) {
-      this.props.navigator.push({
-        screen: Screens.User,
-        animationType: 'fade',
-      });
+      Application.startLoggedInApp();
     }
   }
 

--- a/src/components/TravelFinished/TravelFinished.js
+++ b/src/components/TravelFinished/TravelFinished.js
@@ -16,8 +16,8 @@ import Platform from '../../helpers/Platform';
 import Colors from '../../helpers/Colors';
 import Logo01 from '../../assets/images/Logo01.png';
 import strings from '../../localization';
-import { Screens } from '../Navigation';
 import { transformTime, transformDay, transformMonth } from '../../helpers/DateFormatter';
+import { Screens } from '../Navigation';
 import styles from '../TravelFinished/styles';
 
 Mapbox.setAccessToken('pk.eyJ1IjoicXFtZWxvIiwiYSI6ImNqbWlhOXh2eDAwMHMzcm1tNW1veDNmODYifQ.vOmFAXiikWFJKh3DpmsPDA');
@@ -112,8 +112,11 @@ class TravelFinished extends Component {
 
   changeRole = () => {
     this.props.changeRole();
-    this.props.navigator.pop();
-    this.props.navigator.pop();
+    this.props.navigator.popTo({
+      screen: Screens.Roles,
+      animated: true,
+      animationType: 'fade',
+    });
   };
 
   render() {

--- a/src/components/Weigh/Weigh.js
+++ b/src/components/Weigh/Weigh.js
@@ -103,10 +103,7 @@ class Weigh extends Component {
 
   changeRole = () => {
     this.props.changeRole();
-    this.props.navigator.push({
-      screen: Screens.Roles,
-      animationType: 'fade',
-    });
+    this.props.navigator.pop();
   };
 
   render() {


### PR DESCRIPTION
Back button now works properly on every screen. 
The only detail is when exiting the Travel Finished screen, the navigator is popping twice, navigating through the Gather screen for an instant, but pushing instead of popping isn't an option as the back button would return to the Travel Finished screen instead of the Select User screen.
Also the navigation stack root is now set in the Select User screen.
