### PR TITLE
Unified buttons in extraordinary event modal

### DIFF
--- a/src/actions/GatherActions.js
+++ b/src/actions/GatherActions.js
@@ -148,7 +148,7 @@ export const createExtraEvent = (
       pockets,
       coordinates,
     );
-    dispatch(incrementPocketCounter(pockets.length));
+    dispatch(incrementPocketCounter(1));
     dispatch(createEventSuccess(eventId));
   } catch (error) {
     dispatch(createEventError(error.message));

--- a/src/components/Gather/GatherAddEventModal.js
+++ b/src/components/Gather/GatherAddEventModal.js
@@ -23,24 +23,12 @@ class AddEventModal extends Component {
     descriptionSubmitted: false,
   };
 
-  acceptEdit = () => {
-    if (this.state.identifier > 0) {
-      this.setState(prevState => ({
-        pocketsFromEvent: [...prevState.pocketsFromEvent, { serial_number: this.state.identifier }],
-        identifier: 0,
-      }));
-    } else {
-      this.setState({ inputError: true });
-      this.setState({ errors: [strings.invalidInputId] });
-    }
-  };
-
   closeModal = () => {
     this.props.createExtraEvent(
       this.props.token,
       this.props.collectionId,
       this.state.description,
-      this.state.pocketsFromEvent,
+      this.state.identifier,
       this.props.eventCoordinates,
     );
 
@@ -56,7 +44,7 @@ class AddEventModal extends Component {
   };
 
   acceptAndClose = () => {
-    this.acceptEdit();
+    // this.acceptEdit();
     this.closeModal();
   };
 

--- a/src/components/Gather/GatherAddEventModal.js
+++ b/src/components/Gather/GatherAddEventModal.js
@@ -43,6 +43,7 @@ class AddEventModal extends Component {
       this.state.pocketsFromEvent,
       this.props.eventCoordinates,
     );
+
     // connect to backend
     // resets state so further calls wont interfere with next ones
     this.setState({ inputError: false });
@@ -52,6 +53,11 @@ class AddEventModal extends Component {
     this.setState({ errors: [] });
     this.setState({ descriptionSubmitted: false });
     this.props.toggleModal();
+  };
+
+  acceptAndClose = () => {
+    this.acceptEdit();
+    this.closeModal();
   };
 
   renderModal = (description) => {
@@ -66,20 +72,12 @@ class AddEventModal extends Component {
             onChangeText={value => this.setState({ identifier: value })}
           />
           <View style={stylesGather.modalButtonContainer}>
-            <View style={{ paddingRight: 10 }}>
+            <View>
               <CustomButton
                 style={stylesGather.buttonModalConfirmExit}
                 textStyle={stylesGather.textButton}
                 title={strings.acceptModal}
-                onPress={this.closeModal}
-              />
-            </View>
-            <View style={{ paddingLeft: 10 }}>
-              <CustomButton
-                style={stylesGather.buttonModalConfirmExit}
-                textStyle={stylesGather.textButton}
-                title={strings.keepOnAdding}
-                onPress={this.acceptEdit}
+                onPress={this.acceptAndClose}
               />
             </View>
           </View>

--- a/src/controllers/GatherController.js
+++ b/src/controllers/GatherController.js
@@ -117,7 +117,7 @@ class GatherController {
               description: `${description}`,
             },
             collection: {
-              pockets_attributes: pockets,
+              pockets_attributes: [{ serial_number: pockets }],
             },
           },
           {


### PR DESCRIPTION
Now only one pocket is permitted per event (as requested by PO). Buttons for adding and accepting the pocket have been merged into one.